### PR TITLE
adding support for standalone npm package

### DIFF
--- a/install.js
+++ b/install.js
@@ -3,7 +3,7 @@ import C from './C.js'
 
 try {
 	C.log(34)('Installing node modules...')()
-	execSync('pnpm remove -D sveltekit-zero-api', { stdio: 'inherit' })
+	// execSync('pnpm remove -D sveltekit-zero-api', { stdio: 'inherit' })
 	execSync('pnpm i', { stdio: 'inherit' })
 } catch (error) {
 	console.error(C(31)('... An error occurred:')(), error)

--- a/pack.js
+++ b/pack.js
@@ -8,7 +8,7 @@ let fileData = ''
 try {
 	C.log(34)('Packaging')(0)
 	execSync('pnpm i --ignore-scripts')
-	execSync('pnpm remove sveltekit-zero-api')
+	// execSync('pnpm remove sveltekit-zero-api')
 	fileData = fs.readFileSync('svelte.config.js', 'utf-8')
 	fs.writeFileSync('svelte.config.js', fileData.replace(/(?<=Removed when packaging)[\s\S]*(?=\/\/ --)/, ''), 'utf-8')
 	execSync('set NODE_ENV=package')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,18 +15,18 @@ specifiers:
   vite: ^4.1.1
 
 devDependencies:
-  '@sveltejs/adapter-auto': 2.0.0_@sveltejs+kit@1.5.5
-  '@sveltejs/kit': 1.5.5_svelte@3.55.1+vite@4.1.1
+  '@sveltejs/adapter-auto': 2.0.0_@sveltejs+kit@1.8.5
+  '@sveltejs/kit': 1.8.5_svelte@3.55.1+vite@4.1.4
   '@sveltejs/package': 1.0.2_4x7phaipmicbaooxtnresslofa
   chokidar: 3.5.3
   svelte: 3.55.1
   svelte-check: 2.10.3_svelte@3.55.1
   svelte-preprocess: 4.10.7_4x7phaipmicbaooxtnresslofa
   svelte2tsx: 0.5.23_4x7phaipmicbaooxtnresslofa
-  sveltekit-zero-api: file:sveltekit-zero-api.tgz_mombgr4tqjba7weu533t6lazv4
+  sveltekit-zero-api: file:sveltekit-zero-api.tgz_bpfyswqgnuhxcur64jazwb3gma
   tslib: 2.5.0
   typescript: 4.9.5
-  vite: 4.1.1
+  vite: 4.1.4
 
 packages:
 
@@ -269,17 +269,17 @@ packages:
     resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
     dev: true
 
-  /@sveltejs/adapter-auto/2.0.0_@sveltejs+kit@1.5.5:
+  /@sveltejs/adapter-auto/2.0.0_@sveltejs+kit@1.8.5:
     resolution: {integrity: sha512-b+gkHFZgD771kgV3aO4avHFd7y1zhmMYy9i6xOK7m/rwmwaRO8gnF5zBc0Rgca80B2PMU1bKNxyBTHA14OzUAQ==}
     peerDependencies:
       '@sveltejs/kit': ^1.0.0
     dependencies:
-      '@sveltejs/kit': 1.5.5_svelte@3.55.1+vite@4.1.1
+      '@sveltejs/kit': 1.8.5_svelte@3.55.1+vite@4.1.4
       import-meta-resolve: 2.2.1
     dev: true
 
-  /@sveltejs/kit/1.5.5_svelte@3.55.1+vite@4.1.1:
-    resolution: {integrity: sha512-NJry1mvcIBITVe9WyAGu39Cf33z8wRKzut/Oug4zqMVUpX+i7fG17+GyvLCh9GXdmIkqwSeSMROHDKRODvd6BA==}
+  /@sveltejs/kit/1.8.5_svelte@3.55.1+vite@4.1.4:
+    resolution: {integrity: sha512-b6kbjVAivoPd3oL9IVBaZBWiuHeI0qBKfszSDXcqsPfiSMyUK7ilHDFVSWNn+2EMPO48+87iuho71yTCOXZE3w==}
     engines: {node: ^16.14 || >=18}
     hasBin: true
     requiresBuild: true
@@ -287,21 +287,21 @@ packages:
       svelte: ^3.54.0
       vite: ^4.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.0.2_svelte@3.55.1+vite@4.1.1
+      '@sveltejs/vite-plugin-svelte': 2.0.3_svelte@3.55.1+vite@4.1.4
       '@types/cookie': 0.5.1
       cookie: 0.5.0
       devalue: 4.3.0
       esm-env: 1.0.0
       kleur: 4.1.5
-      magic-string: 0.27.0
+      magic-string: 0.30.0
       mime: 3.0.0
       sade: 1.8.1
       set-cookie-parser: 2.5.1
       sirv: 2.0.2
       svelte: 3.55.1
       tiny-glob: 0.2.9
-      undici: 5.18.0
-      vite: 4.1.1
+      undici: 5.20.0
+      vite: 4.1.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -317,13 +317,13 @@ packages:
       kleur: 4.1.5
       sade: 1.8.1
       svelte: 3.55.1
-      svelte2tsx: 0.6.1_4x7phaipmicbaooxtnresslofa
+      svelte2tsx: 0.6.2_4x7phaipmicbaooxtnresslofa
     transitivePeerDependencies:
       - typescript
     dev: true
 
-  /@sveltejs/vite-plugin-svelte/2.0.2_svelte@3.55.1+vite@4.1.1:
-    resolution: {integrity: sha512-xCEan0/NNpQuL0l5aS42FjwQ6wwskdxC3pW1OeFtEKNZwRg7Evro9lac9HesGP6TdFsTv2xMes5ASQVKbCacxg==}
+  /@sveltejs/vite-plugin-svelte/2.0.3_svelte@3.55.1+vite@4.1.4:
+    resolution: {integrity: sha512-o+cguBFdwIGtRbNkYOyqTM7KvRUffxh5bfK4oJsWKG2obu+v/cbpT03tJrGl58C7tRXo/aEC0/axN5FVHBj0nA==}
     engines: {node: ^14.18.0 || >= 16}
     peerDependencies:
       svelte: ^3.54.0
@@ -332,11 +332,11 @@ packages:
       debug: 4.3.4
       deepmerge: 4.3.0
       kleur: 4.1.5
-      magic-string: 0.27.0
+      magic-string: 0.29.0
       svelte: 3.55.1
       svelte-hmr: 0.15.1_svelte@3.55.1
-      vite: 4.1.1
-      vitefu: 0.2.4_vite@4.1.1
+      vite: 4.1.4
+      vitefu: 0.2.4_vite@4.1.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -345,8 +345,8 @@ packages:
     resolution: {integrity: sha512-COUnqfB2+ckwXXSFInsFdOAWQzCCx+a5hq2ruyj+Vjund94RJQd4LG2u9hnvJrTgunKAaax7ancBYlDrNYxA0g==}
     dev: true
 
-  /@types/node/18.13.0:
-    resolution: {integrity: sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==}
+  /@types/node/18.14.1:
+    resolution: {integrity: sha512-QH+37Qds3E0eDlReeboBxfHbX9omAcBCXEzswCu6jySP642jiM3cYSIkU/REqwhCUqXdonHFuBfJDiAJxMNhaQ==}
     dev: true
 
   /@types/pug/2.0.6:
@@ -356,7 +356,7 @@ packages:
   /@types/sass/1.43.1:
     resolution: {integrity: sha512-BPdoIt1lfJ6B7rw35ncdwBZrAssjcwzI5LByIrYs+tpXlj/CAkuVdRsgZDdP4lq5EjyWzwxZCqAoFyHKFwp32g==}
     dependencies:
-      '@types/node': 18.13.0
+      '@types/node': 18.14.1
     dev: true
 
   /anymatch/3.1.3:
@@ -422,7 +422,7 @@ packages:
     dev: true
 
   /concat-map/0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: true
 
   /cookie/0.5.0:
@@ -645,8 +645,15 @@ packages:
       sourcemap-codec: 1.4.8
     dev: true
 
-  /magic-string/0.27.0:
-    resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
+  /magic-string/0.29.0:
+    resolution: {integrity: sha512-WcfidHrDjMY+eLjlU+8OvwREqHwpgCeKVBUpQ3OhYYuvfaYCUgcbuBzappNzZvg/v8onU3oQj+BYpkOJe9Iw4Q==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.14
+    dev: true
+
+  /magic-string/0.30.0:
+    resolution: {integrity: sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==}
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.14
@@ -809,8 +816,8 @@ packages:
       glob: 7.2.3
     dev: true
 
-  /rollup/3.15.0:
-    resolution: {integrity: sha512-F9hrCAhnp5/zx/7HYmftvsNBkMfLfk/dXUh73hPSM2E3CRgap65orDNJbLetoiUFwSAk6iHPLvBrZ5iHYvzqsg==}
+  /rollup/3.17.2:
+    resolution: {integrity: sha512-qMNZdlQPCkWodrAZ3qnJtvCAl4vpQ8q77uEujVCCbC/6CLB7Lcmvjq7HyiOSnf4fxTT9XgsE36oLHJBH49xjqA==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
@@ -994,8 +1001,8 @@ packages:
       typescript: 4.9.5
     dev: true
 
-  /svelte2tsx/0.6.1_4x7phaipmicbaooxtnresslofa:
-    resolution: {integrity: sha512-O/1+5UyChfmhp1/GUv8b8iveTrn6eZwHxEXc+rw7LMKRidr9KHk5w/EiliLjDUwHa2VA6CoEty+CQylROVU4Sw==}
+  /svelte2tsx/0.6.2_4x7phaipmicbaooxtnresslofa:
+    resolution: {integrity: sha512-0ircYY2/jMOfistf+iq8fVHERnu1i90nku56c78+btC8svyafsc3OjOV37LDEOV7buqYY1Rv/uy03eMxhopH2Q==}
     peerDependencies:
       svelte: ^3.55
       typescript: ^4.9.4
@@ -1035,15 +1042,15 @@ packages:
     hasBin: true
     dev: true
 
-  /undici/5.18.0:
-    resolution: {integrity: sha512-1iVwbhonhFytNdg0P4PqyIAXbdlVZVebtPDvuM36m66mRw4OGrCm2MYynJv/UENFLdP13J1nPVQzVE2zTs1OeA==}
+  /undici/5.20.0:
+    resolution: {integrity: sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==}
     engines: {node: '>=12.18'}
     dependencies:
       busboy: 1.6.0
     dev: true
 
-  /vite/4.1.1:
-    resolution: {integrity: sha512-LM9WWea8vsxhr782r9ntg+bhSFS06FJgCvvB0+8hf8UWtvaiDagKYWXndjfX6kGl74keHJUcpzrQliDXZlF5yg==}
+  /vite/4.1.4:
+    resolution: {integrity: sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
@@ -1070,12 +1077,12 @@ packages:
       esbuild: 0.16.17
       postcss: 8.4.21
       resolve: 1.22.1
-      rollup: 3.15.0
+      rollup: 3.17.2
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
 
-  /vitefu/0.2.4_vite@4.1.1:
+  /vitefu/0.2.4_vite@4.1.4:
     resolution: {integrity: sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==}
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0
@@ -1083,22 +1090,22 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 4.1.1
+      vite: 4.1.4
     dev: true
 
   /wrappy/1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
     dev: true
 
-  file:sveltekit-zero-api.tgz_mombgr4tqjba7weu533t6lazv4:
-    resolution: {integrity: sha512-mc85GZJKZ+PSyHkL1B74TVAvg0eRqvYtBXY4DwUhKUd2oH2FwYdByntBTNlAa9pSB2zVyfyvP3WnOPM9VStgig==, tarball: file:sveltekit-zero-api.tgz}
+  file:sveltekit-zero-api.tgz_bpfyswqgnuhxcur64jazwb3gma:
+    resolution: {integrity: sha512-fwKQa6NigBgiuYbfDGFL2r6IbhePye3zqNro3xoKv1GhUrVxE9WlMTQJnAdAd+TGu4CY1oTvVVLYeVavwEtjcA==, tarball: file:sveltekit-zero-api.tgz}
     id: file:sveltekit-zero-api.tgz
     name: sveltekit-zero-api
-    version: 0.12.0
+    version: 0.12.1
     peerDependencies:
       '@sveltejs/kit': ^1.5.5
       svelte: ^3.55.1
     dependencies:
-      '@sveltejs/kit': 1.5.5_svelte@3.55.1+vite@4.1.1
+      '@sveltejs/kit': 1.8.5_svelte@3.55.1+vite@4.1.4
       svelte: 3.55.1
     dev: true

--- a/src/lib/api-types/api-updater.ts
+++ b/src/lib/api-types/api-updater.ts
@@ -6,6 +6,17 @@ import type { ZeroAPIPluginConfig } from '$lib/vitePlugin.js'
 
 const cwd = process.cwd()
 
+function deleteNestedEmptyObjects(obj: any) {
+	// modify by reference
+	Object.keys(obj).forEach(function(key) {
+		if (typeof obj[key] === 'object') {
+			deleteNestedEmptyObjects(obj[key])
+			if (Object.keys(obj[key]).length === 0) {
+				delete obj[key]
+			}
+		}
+	})
+}
 /** Is run when file changes has been detected */
 export function apiUpdater(
 	config: ZeroAPIPluginConfig,
@@ -57,6 +68,8 @@ export function apiUpdater(
 		}
 		return obj
 	}
+
+	deleteNestedEmptyObjects(apiTypes)
 	apiTypes = fixKeys(apiTypes)
 
 	let dirText = JSON.stringify(apiTypes, null, 2)

--- a/src/lib/api/handler.ts
+++ b/src/lib/api/handler.ts
@@ -45,7 +45,7 @@ export default function handler(options: IOptions, api: APIContent) {
 	if (stringifyQueryObjects && 'query' in api) 
 		stringifyQuery(api)
 
-	const url = options.config.baseUrl || '' + options.path + ('query' in api ? '?' + new URLSearchParams(api.query).toString() : '')
+	const url = (options.config.baseUrl || '') + options.path + ('query' in api ? '?' + new URLSearchParams(api.query).toString() : '')
 	const baseData = options.config.baseData || {}
 
 	const isForm = Object.prototype.toString.call(api.body) === '[object FormData]'

--- a/src/lib/api/handler.ts
+++ b/src/lib/api/handler.ts
@@ -89,7 +89,10 @@ export default function handler(options: IOptions, api: APIContent) {
 	
 	const requestInit: RequestInit = { ...baseData, ...api, headers: { ...(baseData['headers'] || {}), ...(api['headers'] || {}) } }
 	if (api.body === undefined) delete requestInit['body']
-	const response = fetch(url, requestInit)
+	// avoid making the "preflight http request", which will make it twice as fast
+	const collapsedRequestInit = api.method === 'GET' ? undefined : requestInit
+	
+	const response = fetch(url, collapsedRequestInit);
 	response.then(async (res) => {
 		const json = (res.headers.get('content-type')||'').includes('application/json') && await res[options.config.format || 'json']()
 		// TODO: Handle other responses than just JSON


### PR DESCRIPTION
I've created a standalone npm package for the [youtube-browser-api](https://www.npmjs.com/package/youtube-browser-api) and made the necessary changes to the original repository to support it. This allows developers to use the API without having to set up a SvelteKit project.

Here are the commits included in this pull request:

- Fix node install issue (#11)
- Delete empty entries on generated apiTypes
- Replace absolute module paths with relative paths
- Add Slug types to generated apiTypes
- Fix optional baseUrl on API handler
- Add bypass to preflight HTTP request on GET
- Update pnpm-lock.yaml

Please let me know if you have any questions or concerns.