### PR TITLE
fix: endpointPipe flattening classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "sveltekit-zero-api",
 	"description": "Provides type-safety between front- and backend of your SvelteKit project",
-	"version": "0.15.5",
+	"version": "0.15.6",
 	"scripts": {
 		"dev": "set NODE_ENV=zeroapi && vite dev",
 		"package": "svelte-package -w",

--- a/src/lib/pipe.ts
+++ b/src/lib/pipe.ts
@@ -2,7 +2,7 @@ import type { KitEvent, KitResponse } from './index.js'
 import { InternalServerError } from './http.js'
 
 type Fn<KitEv extends KitEvent, TLocals, R, TReturn extends KitResponse | void> =
-	(event: { locals: Flat<TLocals> } & KitEv, n: R) => TReturn | void
+	(event: { locals: Simplify<TLocals> } & KitEv, n: R) => TReturn | void
 
 /**
  * @example


### PR DESCRIPTION
The endpointPipe function was flattening classes for the function parameters event which broke the ability to require a class, e.g. `KitEvent & { locals: { someClass: SomeClass } }`

This fixes that.